### PR TITLE
Fix print flow for RoomBookingsDialog

### DIFF
--- a/src/components/bookly/RoomBookingsDialog.tsx
+++ b/src/components/bookly/RoomBookingsDialog.tsx
@@ -25,7 +25,8 @@ interface RoomBookingsDialogProps {
 export function RoomBookingsDialog({ isOpen, onOpenChange, roomName, date, bookings }: RoomBookingsDialogProps) {
   
   const handlePrint = () => {
-    window.print();
+    onOpenChange(false);
+    setTimeout(() => window.print(), 0);
   };
   
   return (


### PR DESCRIPTION
## Summary
- close the dialog before calling `window.print`

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860545f78c08324b1bac262161ec176