### PR TITLE
Fix bookings view after room deletion

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -218,6 +218,9 @@ export default function AdminPage() {
       if (result.success) {
           toast({ title: 'Room Deleted', description: `Room "${roomToDelete.name}" has been deleted.` });
           fetchRooms();
+          if (showBookingsTable) {
+              await handleShowAllBookings();
+          }
       } else {
           toast({ variant: 'destructive', title: 'Error Deleting Room', description: result.error });
       }


### PR DESCRIPTION
## Summary
- ensure the admin bookings table refreshes after a room is deleted

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68610a878e348324bc573476eb4ea6cf