### PR TITLE
Add multi-admin system with permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This project was bootstrapped with [Firebase Studio](https://firebase.google.com
   - Configuring application-wide settings like booking slot duration and workday hours.
 - **Data Persistence:** Uses a simple flat-file system (JSON) for storing all application data, making it easy to inspect and manage.
 - **Import/Export:** Easily back up and restore all application data (rooms, bookings, settings) with a single click.
+- **Multi-Admin Support:** Manage multiple admin accounts with permission-based access. A default `sysadmin` user is created on first run and must change the password upon initial login.
 
 ## Screenshots
 

--- a/data/admins.json
+++ b/data/admins.json
@@ -1,0 +1,8 @@
+[
+  {
+    "username": "sysadmin",
+    "password": "password",
+    "permissions": ["*"],
+    "requirePasswordChange": true
+  }
+]

--- a/src/app/admin/change-password/page.tsx
+++ b/src/app/admin/change-password/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { updateCurrentAdminPassword } from '@/lib/actions';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+
+export default function ChangePasswordPage() {
+  const router = useRouter();
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('password', password);
+    const res = await updateCurrentAdminPassword(formData);
+    if (res.success) {
+      router.push('/admin');
+    } else {
+      setError(res.error || 'Failed to update password');
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-20 flex justify-center items-center">
+      <div className="w-full max-w-md">
+        <form onSubmit={handleSubmit}>
+          <Card className="shadow-2xl rounded-xl">
+            <CardHeader className="text-center">
+              <CardTitle className="font-headline text-2xl text-primary mt-2">Change Password</CardTitle>
+              <CardDescription>Enter a new password for your account.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="password">New Password</Label>
+                <Input id="password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+              </div>
+              {error && <p className="text-destructive text-sm">{error}</p>}
+            </CardContent>
+            <CardFooter>
+              <Button type="submit" className="w-full">Change Password</Button>
+            </CardFooter>
+          </Card>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -3,7 +3,7 @@
 
 import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { verifyAdminPassword } from '@/lib/actions';
+import { verifyAdminCredentials } from '@/lib/actions';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
@@ -18,16 +18,25 @@ function AdminLoginForm() {
   return (
     <main className="container mx-auto py-20 flex justify-center items-center">
         <div className="w-full max-w-md">
-            <form action={verifyAdminPassword}>
+            <form action={verifyAdminCredentials}>
                 <Card className="shadow-2xl rounded-xl">
                     <CardHeader className="text-center">
                         <div className="mx-auto bg-primary/10 p-3 rounded-full w-fit">
                            <KeyRound className="h-8 w-8 text-primary" />
                         </div>
                         <CardTitle className="font-headline text-2xl text-primary mt-2">Admin Access</CardTitle>
-                        <CardDescription>Please enter the admin password to continue.</CardDescription>
+                        <CardDescription>Please enter your admin credentials to continue.</CardDescription>
                     </CardHeader>
                     <CardContent className="space-y-6">
+                        <div className="space-y-2">
+                            <Label htmlFor="username">Username</Label>
+                            <Input
+                                id="username"
+                                name="username"
+                                placeholder="Enter username"
+                                required
+                            />
+                        </div>
                         <div className="space-y-2">
                             <Label htmlFor="password">Password</Label>
                             <Input

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getAdminAccounts, saveAdminAccount, deleteAdminAccount } from '@/lib/actions';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { PlusCircle, Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import type { AdminAccount } from '@/types';
+
+export default function AdminUsersPage() {
+  const [admins, setAdmins] = useState<AdminAccount[]>([]);
+  const [newUser, setNewUser] = useState('');
+  const [newPass, setNewPass] = useState('');
+
+  useEffect(() => {
+    async function fetchData() {
+      const data = await getAdminAccounts();
+      setAdmins(data);
+    }
+    fetchData();
+  }, []);
+
+  const handleAdd = async () => {
+    if (!newUser || !newPass) return;
+    await saveAdminAccount({ username: newUser, password: newPass, permissions: [], requirePasswordChange: false });
+    const updated = await getAdminAccounts();
+    setAdmins(updated);
+    setNewUser('');
+    setNewPass('');
+  };
+
+  const handleDelete = async (u: string) => {
+    await deleteAdminAccount(u);
+    setAdmins(await getAdminAccounts());
+  };
+
+  return (
+    <main className="container mx-auto py-8 px-4">
+      <Card className="shadow-xl rounded-xl">
+        <CardHeader>
+          <CardTitle className="font-headline text-2xl text-primary">Manage Admins</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex gap-2">
+            <Input placeholder="Username" value={newUser} onChange={e => setNewUser(e.target.value)} />
+            <Input placeholder="Password" type="password" value={newPass} onChange={e => setNewPass(e.target.value)} />
+            <Button onClick={handleAdd}><PlusCircle className="mr-2 h-4 w-4"/>Add</Button>
+            <Link href="/admin" passHref><Button variant="outline">Back</Button></Link>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Username</TableHead>
+                <TableHead>Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {admins.map(a => (
+                <TableRow key={a.username}>
+                  <TableCell>{a.username}</TableCell>
+                  <TableCell>
+                    {a.username !== 'sysadmin' && (
+                      <Button variant="destructive" size="icon" onClick={() => handleDelete(a.username)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/lib/admin-store.ts
+++ b/src/lib/admin-store.ts
@@ -1,0 +1,44 @@
+'use server';
+
+import fs from 'fs';
+import path from 'path';
+import type { AdminAccount } from '@/types';
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const ADMINS_FILE_PATH = path.join(DATA_DIR, 'admins.json');
+
+const DEFAULT_ADMINS: AdminAccount[] = [
+  {
+    username: 'sysadmin',
+    password: 'password',
+    permissions: ['*'],
+    requirePasswordChange: true,
+  },
+];
+
+const ensureDataDirectoryExists = () => {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+};
+
+export const readAdminsFromFile = async (): Promise<AdminAccount[]> => {
+  ensureDataDirectoryExists();
+  try {
+    if (fs.existsSync(ADMINS_FILE_PATH)) {
+      const fileContent = await fs.promises.readFile(ADMINS_FILE_PATH, 'utf-8');
+      if (fileContent && fileContent.trim().length > 0) {
+        return JSON.parse(fileContent) as AdminAccount[];
+      }
+    }
+  } catch (error) {
+    console.error(`[Bookly Admins] Error reading or parsing ${ADMINS_FILE_PATH}:`, error);
+  }
+  await fs.promises.writeFile(ADMINS_FILE_PATH, JSON.stringify(DEFAULT_ADMINS, null, 2));
+  return [...DEFAULT_ADMINS];
+};
+
+export const writeAdminsToFile = async (admins: AdminAccount[]): Promise<void> => {
+  ensureDataDirectoryExists();
+  await fs.promises.writeFile(ADMINS_FILE_PATH, JSON.stringify(admins, null, 2));
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ export const AUTH_COOKIE_NAME = 'bookly-admin-auth';
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const authCookie = request.cookies.get(AUTH_COOKIE_NAME);
-  const isAuthenticated = authCookie?.value === 'true';
+  const isAuthenticated = !!authCookie?.value;
 
   const isLoginPage = pathname.startsWith('/admin/login');
   const isAdminPage = pathname.startsWith('/admin');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -93,3 +93,10 @@ export interface ExportedSettings {
   rooms: Room[];
   bookings: Booking[];
 }
+
+export interface AdminAccount {
+  username: string;
+  password: string;
+  permissions: string[];
+  requirePasswordChange?: boolean;
+}


### PR DESCRIPTION
## Summary
- introduce admin data store
- allow login with username/password and manage accounts
- add change password and admin management pages
- gate dashboard sections by permission
- document multi-admin support

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865a8a10d3c83248eb6a59c6ac3e7ce