### PR TITLE
Improve configuration validation error message

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -288,7 +288,10 @@ export async function updateAppConfiguration(
 
     const finalValidation = appConfigurationSchema.safeParse(newConfig);
     if (!finalValidation.success) {
-        return { success: false, error: 'Validation failed on merged configuration.', fieldErrors: finalValidation.error.flatten().fieldErrors };
+        const fieldErrors = finalValidation.error.flatten().fieldErrors;
+        const firstMessage = Object.values(fieldErrors).flat().find(Boolean);
+        const message = firstMessage ? `Invalid configuration: ${firstMessage}` : 'Merged configuration is invalid.';
+        return { success: false, error: message, fieldErrors };
     }
 
     try {


### PR DESCRIPTION
## Summary
- improve the feedback when the merged configuration validation fails

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ed77996948324bff5ef2dcf0f69c9