### PR TITLE
Handle null logo updates

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -270,8 +270,11 @@ export async function updateAppConfiguration(
     delete safeUpdates.adminPasswordSalt;
 
     const currentConfig = await readConfigurationFromFile();
-    
+
     let processedUpdates = { ...safeUpdates };
+    if (processedUpdates.appLogo === null) {
+      delete processedUpdates.appLogo;
+    }
     if (processedUpdates.appName !== undefined && !processedUpdates.appName.trim()) {
       processedUpdates.appName = DEFAULT_APP_NAME;
     }


### PR DESCRIPTION
## Summary
- guard against `appLogo` null values to preserve existing logo

## Testing
- `npm run typecheck` *(fails: cannot find modules)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686edad0cb448324b3f5ea4d8a5e02eb