### PR TITLE
Handle null logo config

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -686,7 +686,7 @@ const exportedSettingsSchema = z.object({
   appConfig: z.object({
     appName: z.string(),
     appSubtitle: z.string(),
-    appLogo: z.string().optional(),
+    appLogo: z.string().nullable().optional(),
     adminPasswordHash: z.string().optional(),
     adminPasswordSalt: z.string().optional(),
     slotDurationMinutes: z.number(),

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -23,7 +23,12 @@ const DEFAULT_CONFIG: AppConfiguration = {
 };
 
 export const readConfigurationFromFile = async (): Promise<AppConfiguration> => {
-  return await readConfigFromDb(DEFAULT_CONFIG);
+  const cfg = await readConfigFromDb(DEFAULT_CONFIG);
+  const sanitized: Record<string, any> = {};
+  for (const [key, value] of Object.entries(cfg)) {
+    sanitized[key] = value === null ? undefined : value;
+  }
+  return sanitized as AppConfiguration;
 };
 
 export const writeConfigurationToFile = async (config: AppConfiguration): Promise<void> => {


### PR DESCRIPTION
## Summary
- sanitize database config values so `null` becomes `undefined`
- allow `null` for `appLogo` in import schema

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_686edc9eb71c8324b6e9fb509ee2a41f