### PR TITLE
Implement redirect after config save

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -209,7 +209,8 @@ export default function AdminPage() {
 
     if (result.success) {
       toast({ title: 'Configuration Updated', description: 'Your application settings have been saved.' });
-      await fetchAdminConfiguration(); 
+      await fetchAdminConfiguration();
+      router.push('/');
     } else {
       toast({ variant: 'destructive', title: 'Update Failed', description: result.error || 'An unexpected error occurred.' });
     }


### PR DESCRIPTION
## Summary
- redirect to home after admin saves configuration

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686eddf832ac83248cc4815d9055cf70