### PR TITLE
Fix redirect after saving configuration

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -208,11 +208,17 @@ export default function AdminPage() {
     const result = await serverUpdateAppConfiguration(updates);
 
     if (result.success) {
-      toast({ title: 'Configuration Updated', description: 'Your application settings have been saved.' });
-      await fetchAdminConfiguration();
+      toast({
+        title: 'Configuration Updated',
+        description: 'Your application settings have been saved.'
+      });
       router.push('/');
     } else {
-      toast({ variant: 'destructive', title: 'Update Failed', description: result.error || 'An unexpected error occurred.' });
+      toast({
+        variant: 'destructive',
+        title: 'Update Failed',
+        description: result.error || 'An unexpected error occurred.'
+      });
     }
 
     setIsApplyingChanges(false);


### PR DESCRIPTION
## Summary
- fix redirect to home after updating config

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee1b18a4083248249b56374920f66