### PR TITLE
Allow configuring sqlite path

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project was bootstrapped with [Firebase Studio](https://firebase.google.com
   - **Branding:** Change the application's name, subtitle, and upload a custom logo.
   - **Booking Logic:** Set the default booking slot duration (15, 30, or 60 minutes) and define the start and end of the workday to constrain booking times.
   - **Appearance:** Adjust the size of room cards on the home page (Small, Medium, Large) to suit your display needs.
+  - **Database:** Set the path to the SQLite executable used for data storage.
 - **Data Portability:** Export all application data (settings, rooms, and bookings) to a single JSON file for backup, or import from a backup file to instantly restore the application's state.
 - **Security:** Manage access by changing the admin password through a secure form.
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -50,6 +50,7 @@ interface AdminConfigFormState {
   includeWeekends: boolean;
   showHomePageKey: boolean;
   showSlotStrike: boolean;
+  sqlitePath: string;
 }
 
 const convertMinutesToDurationString = (minutes: number): string => {
@@ -77,7 +78,7 @@ export default function AdminPage() {
   const [showBookingsTable, setShowBookingsTable] = useState(false);
 
   // Configuration state
-  const [config, setConfig] = useState<AdminConfigFormState>({ appName: '', appSubtitle: '', slotDuration: '', startOfDay: '', endOfDay: '', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true });
+  const [config, setConfig] = useState<AdminConfigFormState>({ appName: '', appSubtitle: '', slotDuration: '', startOfDay: '', endOfDay: '', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true, sqlitePath: '' });
   const [currentLogo, setCurrentLogo] = useState<string | undefined>(undefined);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
   const [isApplyingChanges, setIsApplyingChanges] = useState(false);
@@ -114,6 +115,7 @@ export default function AdminPage() {
         includeWeekends: !!currentConfig.includeWeekends,
         showHomePageKey: !!currentConfig.showHomePageKey,
         showSlotStrike: !!currentConfig.showSlotStrike,
+        sqlitePath: currentConfig.sqlitePath || 'sqlite3',
       });
       setCurrentLogo(currentConfig.appLogo);
     } catch (err) {
@@ -123,7 +125,7 @@ export default function AdminPage() {
         title: 'Error Fetching Configuration',
         description: 'Could not load current settings. Displaying defaults.',
       });
-      setConfig({ appName: 'Bookly', appSubtitle: 'Room booking system', slotDuration: '1 hour', startOfDay: '09:00', endOfDay: '17:00', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true });
+      setConfig({ appName: 'Bookly', appSubtitle: 'Room booking system', slotDuration: '1 hour', startOfDay: '09:00', endOfDay: '17:00', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true, sqlitePath: 'sqlite3' });
       setCurrentLogo(undefined);
     } finally {
       setIsLoadingConfig(false);
@@ -203,6 +205,7 @@ export default function AdminPage() {
       includeWeekends: config.includeWeekends,
       showHomePageKey: config.showHomePageKey,
       showSlotStrike: config.showSlotStrike,
+      sqlitePath: config.sqlitePath,
     };
 
     const result = await serverUpdateAppConfiguration(updates);
@@ -291,6 +294,7 @@ export default function AdminPage() {
       case 'includeWeekends': return <CalendarDays className="mr-2 h-4 w-4 text-muted-foreground" />;
       case 'showHomePageKey': return <KeySquare className="mr-2 h-4 w-4 text-muted-foreground" />;
       case 'showSlotStrike': return <Slash className="mr-2 h-4 w-4 text-muted-foreground" />;
+      case 'sqlitePath': return <Database className="mr-2 h-4 w-4 text-muted-foreground" />;
       default: return null;
     }
   };
@@ -680,6 +684,14 @@ export default function AdminPage() {
                                     aria-label="Toggle displaying the strike-through on booked slots"
                                 />
                                 </div>
+                            </TableCell>
+                          </TableRow>
+                          <TableRow>
+                            <TableCell className="font-medium pl-6 flex items-center">
+                                {getIconForSetting('sqlitePath')} SQLite Executable Path
+                            </TableCell>
+                            <TableCell className="text-right pr-6">
+                                <Input value={config.sqlitePath} onChange={(e) => handleConfigChange('sqlitePath', e.target.value)} className="text-right sm:w-[220px] ml-auto" placeholder="e.g., /usr/bin/sqlite3" disabled={isApplyingChanges} />
                             </TableCell>
                           </TableRow>
                       </TableBody>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -242,6 +242,7 @@ const appConfigurationObjectSchema = z.object({
   includeWeekends: z.boolean().optional(),
   showHomePageKey: z.boolean().optional(),
   showSlotStrike: z.boolean().optional(),
+  sqlitePath: z.string().optional(),
 });
 
 const appConfigurationSchema = appConfigurationObjectSchema.refine(data => {
@@ -697,6 +698,7 @@ const exportedSettingsSchema = z.object({
     includeWeekends: z.boolean().optional(),
     showHomePageKey: z.boolean().optional(),
     showSlotStrike: z.boolean().optional(),
+    sqlitePath: z.string().optional(),
   }),
   rooms: z.array(z.object({
     id: z.string(),

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -2,7 +2,7 @@
 
 import type { AppConfiguration } from '@/types';
 import { hashPassword } from './crypto';
-import { readConfigFromDb, writeConfigToDb } from './sqlite-db';
+import { readConfigFromDb, writeConfigToDb, setSqliteCliPath } from './sqlite-db';
 
 const { hash: defaultHash, salt: defaultSalt } = hashPassword('password');
 
@@ -20,6 +20,7 @@ const DEFAULT_CONFIG: AppConfiguration = {
   includeWeekends: false,
   showHomePageKey: true,
   showSlotStrike: true,
+  sqlitePath: 'sqlite3',
 };
 
 export const readConfigurationFromFile = async (): Promise<AppConfiguration> => {
@@ -28,11 +29,21 @@ export const readConfigurationFromFile = async (): Promise<AppConfiguration> => 
   for (const [key, value] of Object.entries(cfg)) {
     sanitized[key] = value === null ? undefined : value;
   }
+  if (sanitized.sqlitePath) {
+    setSqliteCliPath(sanitized.sqlitePath);
+  } else {
+    setSqliteCliPath('sqlite3');
+  }
   return sanitized as AppConfiguration;
 };
 
 export const writeConfigurationToFile = async (config: AppConfiguration): Promise<void> => {
   const configToWrite = { ...config };
   delete configToWrite.adminPassword;
+  if (configToWrite.sqlitePath) {
+    setSqliteCliPath(configToWrite.sqlitePath);
+  } else {
+    setSqliteCliPath('sqlite3');
+  }
   await writeConfigToDb(configToWrite as AppConfiguration);
 };

--- a/src/lib/sqlite-db.ts
+++ b/src/lib/sqlite-db.ts
@@ -5,6 +5,11 @@ import fs from 'fs';
 import path from 'path';
 import type { Room, Booking, AppConfiguration } from '@/types';
 
+let SQLITE_CMD = 'sqlite3';
+export function setSqliteCliPath(path: string) {
+  SQLITE_CMD = path || 'sqlite3';
+}
+
 const DATA_DIR = path.join(process.cwd(), 'data');
 const DB_PATH = path.join(DATA_DIR, 'bookly.sqlite');
 
@@ -12,7 +17,7 @@ function ensureDb() {
   if (!fs.existsSync(DATA_DIR)) {
     fs.mkdirSync(DATA_DIR, { recursive: true });
   }
-  execFileSync('sqlite3', [DB_PATH, `
+  execFileSync(SQLITE_CMD, [DB_PATH, `
     PRAGMA journal_mode=WAL;
     CREATE TABLE IF NOT EXISTS rooms (
       id TEXT PRIMARY KEY,
@@ -38,12 +43,12 @@ function ensureDb() {
 
 function run(sql: string) {
   ensureDb();
-  execFileSync('sqlite3', [DB_PATH, sql]);
+  execFileSync(SQLITE_CMD, [DB_PATH, sql]);
 }
 
 function query(sql: string) {
   ensureDb();
-  const result = execFileSync('sqlite3', ['-json', DB_PATH, sql], { encoding: 'utf8' }).trim();
+  const result = execFileSync(SQLITE_CMD, ['-json', DB_PATH, sql], { encoding: 'utf8' }).trim();
   return result ? JSON.parse(result) : [];
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,6 +87,7 @@ export interface AppConfiguration {
   includeWeekends?: boolean;
   showHomePageKey?: boolean;
   showSlotStrike?: boolean;
+  sqlitePath?: string;
 }
 
 export interface RoomFormData {


### PR DESCRIPTION
## Summary
- add sqlite path field to configuration
- expose path config in admin dashboard
- support setting sqlite path in sqlite access layer
- document sqlite path setting

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ee465b91483248dece0e4814ef0b1