### PR TITLE
Fix server action rule violation

### DIFF
--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -30,9 +30,9 @@ export const readConfigurationFromFile = async (): Promise<AppConfiguration> => 
     sanitized[key] = value === null ? undefined : value;
   }
   if (sanitized.sqlitePath) {
-    setSqliteCliPath(sanitized.sqlitePath);
+    await setSqliteCliPath(sanitized.sqlitePath);
   } else {
-    setSqliteCliPath('sqlite3');
+    await setSqliteCliPath('sqlite3');
   }
   return sanitized as AppConfiguration;
 };
@@ -41,9 +41,9 @@ export const writeConfigurationToFile = async (config: AppConfiguration): Promis
   const configToWrite = { ...config };
   delete configToWrite.adminPassword;
   if (configToWrite.sqlitePath) {
-    setSqliteCliPath(configToWrite.sqlitePath);
+    await setSqliteCliPath(configToWrite.sqlitePath);
   } else {
-    setSqliteCliPath('sqlite3');
+    await setSqliteCliPath('sqlite3');
   }
   await writeConfigToDb(configToWrite as AppConfiguration);
 };

--- a/src/lib/sqlite-db.ts
+++ b/src/lib/sqlite-db.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import type { Room, Booking, AppConfiguration } from '@/types';
 
 let SQLITE_CMD = 'sqlite3';
-export function setSqliteCliPath(path: string) {
+export async function setSqliteCliPath(path: string): Promise<void> {
   SQLITE_CMD = path || 'sqlite3';
 }
 


### PR DESCRIPTION
## Summary
- make `setSqliteCliPath` asynchronous
- await calls to `setSqliteCliPath` in config store

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ee666db3083248f55409c4e0388dc