### PR TITLE
Remove SQLite path setting

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -50,7 +50,6 @@ interface AdminConfigFormState {
   includeWeekends: boolean;
   showHomePageKey: boolean;
   showSlotStrike: boolean;
-  sqlitePath: string;
 }
 
 const convertMinutesToDurationString = (minutes: number): string => {
@@ -78,7 +77,7 @@ export default function AdminPage() {
   const [showBookingsTable, setShowBookingsTable] = useState(false);
 
   // Configuration state
-  const [config, setConfig] = useState<AdminConfigFormState>({ appName: '', appSubtitle: '', slotDuration: '', startOfDay: '', endOfDay: '', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true, sqlitePath: '' });
+  const [config, setConfig] = useState<AdminConfigFormState>({ appName: '', appSubtitle: '', slotDuration: '', startOfDay: '', endOfDay: '', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true });
   const [currentLogo, setCurrentLogo] = useState<string | undefined>(undefined);
   const [isLoadingConfig, setIsLoadingConfig] = useState(true);
   const [isApplyingChanges, setIsApplyingChanges] = useState(false);
@@ -115,7 +114,6 @@ export default function AdminPage() {
         includeWeekends: !!currentConfig.includeWeekends,
         showHomePageKey: !!currentConfig.showHomePageKey,
         showSlotStrike: !!currentConfig.showSlotStrike,
-        sqlitePath: currentConfig.sqlitePath || 'sqlite3',
       });
       setCurrentLogo(currentConfig.appLogo);
     } catch (err) {
@@ -125,7 +123,7 @@ export default function AdminPage() {
         title: 'Error Fetching Configuration',
         description: 'Could not load current settings. Displaying defaults.',
       });
-      setConfig({ appName: 'Bookly', appSubtitle: 'Room booking system', slotDuration: '1 hour', startOfDay: '09:00', endOfDay: '17:00', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true, sqlitePath: 'sqlite3' });
+      setConfig({ appName: 'Bookly', appSubtitle: 'Room booking system', slotDuration: '1 hour', startOfDay: '09:00', endOfDay: '17:00', homePageScale: 'sm', weekStartsOnMonday: false, includeWeekends: false, showHomePageKey: true, showSlotStrike: true });
       setCurrentLogo(undefined);
     } finally {
       setIsLoadingConfig(false);
@@ -205,7 +203,6 @@ export default function AdminPage() {
       includeWeekends: config.includeWeekends,
       showHomePageKey: config.showHomePageKey,
       showSlotStrike: config.showSlotStrike,
-      sqlitePath: config.sqlitePath,
     };
 
     const result = await serverUpdateAppConfiguration(updates);
@@ -294,7 +291,6 @@ export default function AdminPage() {
       case 'includeWeekends': return <CalendarDays className="mr-2 h-4 w-4 text-muted-foreground" />;
       case 'showHomePageKey': return <KeySquare className="mr-2 h-4 w-4 text-muted-foreground" />;
       case 'showSlotStrike': return <Slash className="mr-2 h-4 w-4 text-muted-foreground" />;
-      case 'sqlitePath': return <Database className="mr-2 h-4 w-4 text-muted-foreground" />;
       default: return null;
     }
   };
@@ -684,14 +680,6 @@ export default function AdminPage() {
                                     aria-label="Toggle displaying the strike-through on booked slots"
                                 />
                                 </div>
-                            </TableCell>
-                          </TableRow>
-                          <TableRow>
-                            <TableCell className="font-medium pl-6 flex items-center">
-                                {getIconForSetting('sqlitePath')} SQLite Executable Path
-                            </TableCell>
-                            <TableCell className="text-right pr-6">
-                                <Input value={config.sqlitePath} onChange={(e) => handleConfigChange('sqlitePath', e.target.value)} className="text-right sm:w-[220px] ml-auto" placeholder="e.g., /usr/bin/sqlite3" disabled={isApplyingChanges} />
                             </TableCell>
                           </TableRow>
                       </TableBody>

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -242,7 +242,6 @@ const appConfigurationObjectSchema = z.object({
   includeWeekends: z.boolean().optional(),
   showHomePageKey: z.boolean().optional(),
   showSlotStrike: z.boolean().optional(),
-  sqlitePath: z.string().optional(),
 });
 
 const appConfigurationSchema = appConfigurationObjectSchema.refine(data => {
@@ -698,7 +697,6 @@ const exportedSettingsSchema = z.object({
     includeWeekends: z.boolean().optional(),
     showHomePageKey: z.boolean().optional(),
     showSlotStrike: z.boolean().optional(),
-    sqlitePath: z.string().optional(),
   }),
   rooms: z.array(z.object({
     id: z.string(),

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -2,7 +2,7 @@
 
 import type { AppConfiguration } from '@/types';
 import { hashPassword } from './crypto';
-import { readConfigFromDb, writeConfigToDb, setSqliteCliPath } from './sqlite-db';
+import { readConfigFromDb, writeConfigToDb } from './sqlite-db';
 
 const { hash: defaultHash, salt: defaultSalt } = hashPassword('password');
 
@@ -20,7 +20,6 @@ const DEFAULT_CONFIG: AppConfiguration = {
   includeWeekends: false,
   showHomePageKey: true,
   showSlotStrike: true,
-  sqlitePath: 'sqlite3',
 };
 
 export const readConfigurationFromFile = async (): Promise<AppConfiguration> => {
@@ -29,21 +28,11 @@ export const readConfigurationFromFile = async (): Promise<AppConfiguration> => 
   for (const [key, value] of Object.entries(cfg)) {
     sanitized[key] = value === null ? undefined : value;
   }
-  if (sanitized.sqlitePath) {
-    await setSqliteCliPath(sanitized.sqlitePath);
-  } else {
-    await setSqliteCliPath('sqlite3');
-  }
   return sanitized as AppConfiguration;
 };
 
 export const writeConfigurationToFile = async (config: AppConfiguration): Promise<void> => {
   const configToWrite = { ...config };
   delete configToWrite.adminPassword;
-  if (configToWrite.sqlitePath) {
-    await setSqliteCliPath(configToWrite.sqlitePath);
-  } else {
-    await setSqliteCliPath('sqlite3');
-  }
   await writeConfigToDb(configToWrite as AppConfiguration);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -87,7 +87,6 @@ export interface AppConfiguration {
   includeWeekends?: boolean;
   showHomePageKey?: boolean;
   showSlotStrike?: boolean;
-  sqlitePath?: string;
 }
 
 export interface RoomFormData {


### PR DESCRIPTION
## Summary
- drop `sqlitePath` field from admin settings page
- remove `sqlitePath` from application configuration types and schemas
- cleanup config store logic

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ee7bfc89c8324a4e64ffd68787b35