### PR TITLE
Enforce password each admin visit

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -41,12 +41,15 @@ export async function verifyAdminPassword(formData: FormData) {
   const isValid = verifyPassword(password, config.adminPasswordHash, config.adminPasswordSalt);
 
   if (isValid) {
+    // Set a short-lived cookie that will be cleared by the middleware after the
+    // next request. This ensures the admin password is required for every page
+    // visit.
     cookies().set(AUTH_COOKIE_NAME, 'true', {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       path: '/',
       sameSite: 'strict',
-      maxAge: 60 * 60 * 24, // 1 day
+      maxAge: 60, // just long enough for the redirect
     });
     redirect(from);
   } else {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -23,7 +23,16 @@ export function middleware(request: NextRequest) {
   }
 
   // Otherwise, allow the request to proceed.
-  return NextResponse.next()
+  const response = NextResponse.next()
+
+  // Once an admin page is served, immediately clear the auth cookie so that the
+  // next visit requires the password again. This effectively forces password
+  // entry on every admin request.
+  if (isAuthenticated && isAdminPage && !isLoginPage) {
+    response.cookies.delete(AUTH_COOKIE_NAME)
+  }
+
+  return response
 }
 
 // Match all paths under /admin to ensure this logic runs for both the


### PR DESCRIPTION
## Summary
- set admin auth cookie to expire quickly
- delete auth cookie in middleware so admin must login for each request

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68701e399acc83248c0a433cdd628287