### PR TITLE
Fix cookie API usage

### DIFF
--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -44,7 +44,8 @@ export async function verifyAdminPassword(formData: FormData) {
     // Set a short-lived cookie that will be cleared by the middleware after the
     // next request. This ensures the admin password is required for every page
     // visit.
-    cookies().set(AUTH_COOKIE_NAME, 'true', {
+    const cookieStore = await cookies();
+    cookieStore.set(AUTH_COOKIE_NAME, 'true', {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       path: '/',
@@ -106,7 +107,8 @@ export async function changeAdminPassword(formData: FormData) {
 }
 
 export async function logoutAdmin() {
-  cookies().delete(AUTH_COOKIE_NAME);
+  const cookieStore = await cookies();
+  cookieStore.delete(AUTH_COOKIE_NAME);
   redirect('/admin/login');
 }
 


### PR DESCRIPTION
## Summary
- fix cookie API usage in admin login flow

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687022065524832485127b99206fc834