### PR TITLE
Print version info on dev startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node scripts/print-version.js",
     "dev": "next dev --turbopack -p 9002",
     "build": "next build",
     "start": "next start",

--- a/scripts/print-version.js
+++ b/scripts/print-version.js
@@ -1,0 +1,24 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function getPackageVersion() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    return pkg.version || 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getGitCommit() {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const version = getPackageVersion();
+const commit = getGitCommit();
+console.log(`Bookly version: ${version} (commit ${commit})`);


### PR DESCRIPTION
## Summary
- show Bookly version and commit hash whenever the dev server is started

## Testing
- `npm run dev` *(fails: `next` not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68702c0f81c08324bfb1307009a7ecf5