### PR TITLE
Restrict admin creation & add management actions

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,1 +1,3 @@
 export const AUTH_COOKIE_NAME = 'bookly-admin-auth';
+export const ADMIN_USER_COOKIE = 'bookly-admin-user';
+export const ADMIN_PRIMARY_COOKIE = 'bookly-admin-primary';


### PR DESCRIPTION
## Summary
- extend admin cookie definitions
- store username and primary status on login
- expose current admin via server action
- add delete and update actions for secondary admins
- update logout to clear extra cookies
- enhance create-admin page with password update and delete features

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68703076179c83248784c39814353647