### PR TITLE
Expand admin page width

### DIFF
--- a/src/app/admin/create-admin/page.tsx
+++ b/src/app/admin/create-admin/page.tsx
@@ -145,7 +145,7 @@ function CreateAdminForm() {
 export default function CreateAdminPage() {
   return (
     <main className="container mx-auto py-20 flex justify-center items-center">
-      <div className="w-full max-w-md">
+      <div className="w-full max-w-4xl">
         <Suspense>
           <CreateAdminForm />
         </Suspense>


### PR DESCRIPTION
## Summary
- widen the container on the Manage Secondary Admins page

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68704355465883249a2789c27b1a9887