### PR TITLE
Admin role tweaks

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -18,7 +18,8 @@ import {
     deleteRoom,
     exportAllSettings,
     importAllSettings,
-    logoutAdmin
+    logoutAdmin,
+    getCurrentAdmin
 } from '@/lib/actions';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -83,6 +84,7 @@ export default function AdminPage() {
   const [isApplyingChanges, setIsApplyingChanges] = useState(false);
   const [isUploadingLogo, setIsUploadingLogo] = useState(false);
   const [isRevertingLogo, setIsRevertingLogo] = useState(false);
+  const [adminInfo, setAdminInfo] = useState<{ username: string; isPrimary: boolean } | null>(null);
 
 
   // Rooms state
@@ -165,6 +167,7 @@ export default function AdminPage() {
   useEffect(() => {
     fetchAdminConfiguration();
     fetchRooms();
+    getCurrentAdmin().then(setAdminInfo).catch(() => setAdminInfo(null));
   }, [fetchAdminConfiguration, fetchRooms]);
 
   const roomMap = useMemo(() => new Map<string, Room>(rooms.map(room => [room.id, room])), [rooms]);
@@ -710,9 +713,11 @@ export default function AdminPage() {
                   <Button asChild variant="outline">
                     <Link href="/admin/change-password">Change Password</Link>
                   </Button>
-                  <Button asChild variant="outline" className="ml-2 mt-2 sm:mt-0">
-                    <Link href="/admin/create-admin">Manage Admins</Link>
-                  </Button>
+                  {adminInfo?.isPrimary && (
+                    <Button asChild variant="outline" className="ml-2 mt-2 sm:mt-0">
+                      <Link href="/admin/create-admin">Manage Admins</Link>
+                    </Button>
+                  )}
                 </CardContent>
               </Card>
             </div>

--- a/src/components/bookly/Header.tsx
+++ b/src/components/bookly/Header.tsx
@@ -67,8 +67,11 @@ export function Header({ config }: HeaderProps) {
             </span>
           )}
           {adminInfo && (
-            <span className="text-xs text-muted-foreground">
-              {adminInfo.username} ({adminInfo.isPrimary ? 'Primary' : 'Secondary'} Admin)
+            <span className="text-xs text-muted-foreground flex items-center">
+              {adminInfo.username}
+              <span className="ml-1 inline-flex items-center justify-center w-4 h-4 rounded-full bg-muted text-foreground text-[10px] font-semibold">
+                {adminInfo.isPrimary ? '1' : '2'}
+              </span>
             </span>
           )}
           <Link href="/admin" passHref>


### PR DESCRIPTION
## Summary
- hide Manage Admins button for secondary admins
- show admin role indicator next to the username

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_687045b480e083248b56dba49822b676