### PR TITLE
Fix home page booking refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,8 @@
 import { getRoomsWithDailyUsage, getCurrentConfiguration } from '@/lib/actions';
 import { RoomGrid } from '@/components/bookly/RoomGrid';
 
+export const dynamic = 'force-dynamic';
+
 export default async function HomePage() {
   const [roomsWithUsage, config] = await Promise.all([
     getRoomsWithDailyUsage(),


### PR DESCRIPTION
## Summary
- force dynamic rendering for Home page so latest bookings show immediately after booking

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68704da49e8c832489b0a4e73445f7db