### PR TITLE
Fix home page date persistence

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,9 +4,13 @@ import { RoomGrid } from '@/components/bookly/RoomGrid';
 
 export const dynamic = 'force-dynamic';
 
-export default async function HomePage() {
+export default async function HomePage({
+  searchParams,
+}: {
+  searchParams?: { startDate?: string };
+}) {
   const [roomsWithUsage, config] = await Promise.all([
-    getRoomsWithDailyUsage(),
+    getRoomsWithDailyUsage(searchParams?.startDate),
     getCurrentConfiguration(),
   ]);
 


### PR DESCRIPTION
## Summary
- keep selected startDate query on the home page
- initialize RoomGrid with startDate from URL and update URL when navigating weeks

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails to run: modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68705179eebc8324802adb66623dc10b