### PR TITLE
Move admin button to home footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default async function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
         <link href="https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />
       </head>
-      <body className="font-body antialiased bg-background text-foreground">
+      <body className="font-body antialiased bg-background text-foreground min-h-screen flex flex-col">
         <UserProvider>
           <Header config={config} />
           {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 
 import { getRoomsWithDailyUsage, getCurrentConfiguration } from '@/lib/actions';
 import { RoomGrid } from '@/components/bookly/RoomGrid';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { UserCog } from 'lucide-react';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,12 +18,22 @@ export default async function HomePage({
   ]);
 
   return (
-    <main className="flex-grow flex flex-col items-center justify-center p-6">
-      {roomsWithUsage.length > 0 ? (
-          <RoomGrid initialRoomsWithUsage={roomsWithUsage} config={config} />
-      ) : (
-         <p className="text-muted-foreground">No rooms have been configured. Please add a room in the admin panel.</p>
-      )}
+    <main className="flex flex-col flex-grow">
+      <div className="flex-grow flex flex-col items-center justify-center p-6">
+        {roomsWithUsage.length > 0 ? (
+            <RoomGrid initialRoomsWithUsage={roomsWithUsage} config={config} />
+        ) : (
+           <p className="text-muted-foreground">No rooms have been configured. Please add a room in the admin panel.</p>
+        )}
+      </div>
+      <div className="pb-6 flex justify-center">
+        <Link href="/admin" passHref>
+          <Button variant="ghost" size="sm">
+            <UserCog className="mr-2 h-5 w-5" />
+            Admin
+          </Button>
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/components/bookly/Header.tsx
+++ b/src/components/bookly/Header.tsx
@@ -74,12 +74,6 @@ export function Header({ config }: HeaderProps) {
               </span>
             </span>
           )}
-          <Link href="/admin" passHref>
-            <Button variant="ghost" size="sm">
-              <UserCog className="mr-2 h-5 w-5" />
-              Admin
-            </Button>
-          </Link>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove admin link from the header
- show admin login button at the bottom of the home page
- make the layout body take full screen height so footer placement works

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870b1cbe04c8324a0cd19bb806b6840