### PR TITLE
fix: refresh layout after logo updates

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -369,6 +369,7 @@ export default function AdminPage() {
     if (result.success && result.logoPath) {
         toast({ title: 'Logo Updated', description: 'Your new logo has been uploaded.' });
         setCurrentLogo(result.logoPath);
+        router.refresh();
         if (fileInput) fileInput.value = '';
     } else {
         toast({ variant: 'destructive', title: 'Logo Upload Failed', description: result.error || 'An unexpected error occurred.' });
@@ -384,6 +385,7 @@ export default function AdminPage() {
     if (result.success) {
         toast({ title: 'Logo Reverted', description: 'The application is now using the default logo.' });
         setCurrentLogo(undefined);
+        router.refresh();
     } else {
         toast({ variant: 'destructive', title: 'Revert Failed', description: result.error || 'An unexpected error occurred.' });
     }


### PR DESCRIPTION
## Summary
- refresh the admin experience after uploading a new logo so the new icon shows immediately
- refresh the layout after reverting to the default logo to restore the default icon right away

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69014471bb3c83248a21acd5578cd9e4