### PR TITLE
Fix missing logo cleanup in configuration loader

### DIFF
--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -1,5 +1,8 @@
 'use server';
 
+import fs from 'fs';
+import path from 'path';
+
 import type { AppConfiguration } from '@/types';
 import { PANEL_COLOR_DEFAULT_VALUE, PANEL_COLOR_VALUE_SET } from './panel-colors';
 import { hashPassword } from './crypto';
@@ -28,6 +31,8 @@ const DEFAULT_CONFIG: AppConfiguration = {
   panelColorOverrideEnabled: false,
 };
 
+const PUBLIC_DIRECTORY = path.join(process.cwd(), 'public');
+
 export const readConfigurationFromFile = async (): Promise<AppConfiguration> => {
   const cfg = await readConfigFromDb(DEFAULT_CONFIG);
   const sanitized: Record<string, any> = {};
@@ -52,7 +57,7 @@ export const readConfigurationFromFile = async (): Promise<AppConfiguration> => 
   if (sanitized.panelColorOverride && !PANEL_COLOR_VALUE_SET.has(sanitized.panelColorOverride)) {
     sanitized.panelColorOverride = PANEL_COLOR_DEFAULT_VALUE;
   }
-  return sanitized as AppConfiguration;
+  return await ensureAppLogoAvailability(sanitized as AppConfiguration);
 };
 
 export const writeConfigurationToFile = async (config: AppConfiguration): Promise<void> => {
@@ -60,3 +65,37 @@ export const writeConfigurationToFile = async (config: AppConfiguration): Promis
   delete configToWrite.adminPassword;
   await writeConfigToDb(configToWrite as AppConfiguration);
 };
+
+async function ensureAppLogoAvailability(config: AppConfiguration): Promise<AppConfiguration> {
+  const logoPath = config.appLogo;
+
+  if (!logoPath) {
+    return config;
+  }
+
+  const relativeLogoPath = logoPath.startsWith('/') ? logoPath.slice(1) : logoPath;
+  if (!relativeLogoPath) {
+    return config;
+  }
+
+  const expectedFilePath = path.join(PUBLIC_DIRECTORY, relativeLogoPath);
+  const logoExists = fs.existsSync(expectedFilePath);
+
+  if (logoExists) {
+    return config;
+  }
+
+  if (!relativeLogoPath.startsWith('app-logo-')) {
+    return config;
+  }
+
+  const updatedConfig = { ...config, appLogo: undefined };
+
+  try {
+    await writeConfigurationToFile(updatedConfig);
+  } catch (error) {
+    console.error('[Config Store] Failed to clear missing logo reference:', error);
+  }
+
+  return updatedConfig;
+}


### PR DESCRIPTION
## Summary
- ensure the configuration loader validates generated logo file paths and clears missing references

## Testing
- npm run lint *(fails: Converting circular structure to JSON referenced from .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_69014c99aa0c83248c610e1c7079263d