### PR TITLE
fix: stabilize logo asset handling

### DIFF
--- a/src/components/bookly/LogoImage.tsx
+++ b/src/components/bookly/LogoImage.tsx
@@ -1,4 +1,7 @@
+
 'use client';
+
+import Image from 'next/image';
 
 import { cn } from '@/lib/utils';
 
@@ -27,14 +30,13 @@ export function LogoImage({ src, alt, size = 40, className }: LogoImageProps) {
   const resolvedSrc = resolveLogoSrc(src);
 
   return (
-    <img
+    <Image
       src={resolvedSrc}
       alt={alt}
       width={size}
       height={size}
-      loading="lazy"
-      decoding="async"
       className={cn('object-contain', className)}
+      unoptimized
     />
   );
 }

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -32,6 +32,7 @@ const DEFAULT_CONFIG: AppConfiguration = {
 };
 
 const PUBLIC_DIRECTORY = path.join(process.cwd(), 'public');
+const APP_LOGO_FILE_NAME = 'app-logo.png';
 
 export const readConfigurationFromFile = async (): Promise<AppConfiguration> => {
   const cfg = await readConfigFromDb(DEFAULT_CONFIG);
@@ -78,14 +79,23 @@ async function ensureAppLogoAvailability(config: AppConfiguration): Promise<AppC
     return config;
   }
 
-  const expectedFilePath = path.join(PUBLIC_DIRECTORY, relativeLogoPath);
+  const [relativeLogoFile] = relativeLogoPath.split('?');
+
+  if (!relativeLogoFile) {
+    return config;
+  }
+
+  const expectedFilePath = path.join(PUBLIC_DIRECTORY, relativeLogoFile);
   const logoExists = fs.existsSync(expectedFilePath);
 
   if (logoExists) {
     return config;
   }
 
-  if (!relativeLogoPath.startsWith('app-logo-')) {
+  if (
+    relativeLogoFile !== APP_LOGO_FILE_NAME &&
+    !relativeLogoFile.startsWith('app-logo-')
+  ) {
     return config;
   }
 


### PR DESCRIPTION
## Summary
- store the uploaded logo at `public/app-logo.png` and keep a cache-busted reference in configuration
- require PNG uploads, delete the stable file on revert, and clean up legacy timestamped assets
- render the branding logo with `next/image`

## Testing
- npm run lint *(fails: Converting circular structure to JSON in .eslintrc.json)*

------
https://chatgpt.com/codex/tasks/task_e_69014dd03c60832489d71be55d39c52b